### PR TITLE
macOS link warning: libmdbxd.a(lck-windows.c.o) has no symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,10 @@ else()
       "${MDBX_SOURCE_DIR}/options.h" "${MDBX_SOURCE_DIR}/base.h"
       "${MDBX_SOURCE_DIR}/internals.h" "${MDBX_SOURCE_DIR}/osal.h"
       "${MDBX_SOURCE_DIR}/core.c" "${MDBX_SOURCE_DIR}/osal.c"
-      "${MDBX_SOURCE_DIR}/lck-posix.c" "${MDBX_SOURCE_DIR}/lck-windows.c")
+      "${MDBX_SOURCE_DIR}/lck-posix.c")
+    if(WIN32)
+      list(APPEND LIBMDBX_SOURCES "${MDBX_SOURCE_DIR}/lck-windows.c")
+    endif()
     include_directories("${MDBX_SOURCE_DIR}")
   endif()
 endif(MDBX_AMALGAMATED_SOURCE)


### PR DESCRIPTION
Building on macOS shows this warning during linking:

Linking CXX static library libmdbxd.a
/Applications/Xcode133.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: third_party/libmdbx/libmdbxd.a(lck-windows.c.o) has no symbols